### PR TITLE
change adoc to md

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,27 +1,33 @@
-= main-fns
+# main-fns
 
-image:https://img.shields.io/badge/License-MIT-yellow.svg[main-fns license, link=https://github.com/nabby27/main-fns/blob/main/LICENSE] image:https://img.shields.io/npm/v/main-fns.svg?style=flat&label=version[main-fns version, link=https://www.npmjs.com/package/main-fns] image:https://img.shields.io/github/workflow/status/nabby27/main-fns/Test/main?label=test[Status test, link=https://github.com/nabby27/main-fns/actions?query=workflow%3A%22Test%22] image:https://img.shields.io/codecov/c/github/nabby27/main-fns/main[Code coverage, link=https://codecov.io/gh/nabby27/main-fns/branch/main] image:https://badgen.net/bundlephobia/tree-shaking/main-fns/[Tree shaking] image:https://badgen.net/bundlephobia/minzip/main-fns[minzipped size] image:https://img.shields.io/npm/dw/main-fns[npm version] image:https://img.shields.io/badge/paypal-donate-yellow.svg[paypal, https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=M57SG9J5RQ6DJ&currency_code=EUR&source=url]
+[![MIT License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/nabby27/main-fns/blob/main/LICENSE)
+[![Version](https://img.shields.io/npm/v/main-fns.svg?style=flat&label=version)](https://www.npmjs.com/package/main-fns)
+[![Build Status](https://img.shields.io/github/workflow/status/nabby27/main-fns/Test/main?label=test)](https://github.com/nabby27/main-fns/actions?query=workflow%3A%22Test%22)
+[![Codecov branch](https://img.shields.io/codecov/c/github/nabby27/main-fns/main)](https://codecov.io/gh/nabby27/main-fns/branch/main)
+![tree shaking](https://badgen.net/bundlephobia/tree-shaking/main-fns/)
+![minzip](https://badgen.net/bundlephobia/minzip/main-fns)
+![npm](https://img.shields.io/npm/dw/main-fns)
+[![PayPal](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=M57SG9J5RQ6DJ&currency_code=EUR&source=url)
 
 Javascript utility library created with TypeScript
 
-== Documentation
-Feel free to investigate the link:https://nabby27.github.io/main-fns/[main-fns documentation], it is structured by modules and created using JSDoc.
+## Documentation
+Feel free to investigate the [main-fns documentation](https://nabby27.github.io/main-fns/), it is structured by modules and created using JSDoc.
 
-== Why main-fns?
+## Why main-fns?
 It is quite tedious to be aware of all the dependencies and keep their changes. The idea of main-fns is that you only worry about this library. Main-fns will have all the main functions that are used in a common way such as the handling of dates, texts, arrays, numbers... Internally main-fns will use the best implementation of the moment and it will be updated for you.
 
-== Installation
+## Installation
 
 Using npm:
-[source, shell]
-----
+
+```sh
 npm i main-fns
-----
+```
 
-== Some examples
+## Some examples
 
-[source, javascript]
-----
+```ts
 import { addDays, camelCase, max } from 'main-fns'
 
 addDays(1, new Date(1996, 5, 26)) // new Date(1996, 5, 27)
@@ -29,16 +35,16 @@ addDays(1, new Date(1996, 5, 26)) // new Date(1996, 5, 27)
 camelCase('hello world') // helloWorld
 
 max(3, 4, 5, 2) // 5
-----
+```
 
-== How to contribute?
+## How to contribute?
 
-See de link:https://github.com/nabby27/main-fns/blob/main/.github/CONTRIBUTING.adoc[CONTRIBUTING] page
+See de [CONTRIBUTING](https://github.com/nabby27/main-fns/blob/main/.github/CONTRIBUTING.md) page
 
-== What changes does it have?
+## What changes does it have?
 
-Detailed changes for each release are documented in the link:https://github.com/nabby27/main-fns/blob/main/CHANGELOG.adoc[CHANGELOG] page or in link:https://github.com/nabby27/main-fns/releases[release notes].
+Detailed changes for each release are documented in the [CHANGELOG](https://github.com/nabby27/main-fns/blob/main/CHANGELOG.md) page or in [release notes](https://github.com/nabby27/main-fns/releases).
 
-== License
+## License
 
-See de link:https://github.com/nabby27/main-fns/blob/main/LICENSE[LICENSE] page
+See de [LICENSE](https://github.com/nabby27/main-fns/blob/main/LICENSE) page


### PR DESCRIPTION
# Description

In the JSDoc documentation and the npm information page they need the readme to be in `md` format instead of `asciidoc`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I generate JSDoc documentation (if needed)
- [ ] I have made corresponding changes to the CHANGELOG
- [ ] I have added unit tests (if needed) that prove my fix is effective or my feature works
- [ ] I have added integration tests (if needed) that prove my fix is effective or my feature works
- [ ] I have added e2e tests that prove my fix is effective or my feature works
- [x] Linter pass locally with my changes
- [x] New and existing tests pass locally with my changes